### PR TITLE
Use new evaluations endpoint

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -113,12 +113,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.21.2</version>
-        </dependency>
-        <dependency>
-            <groupId>com.fasterxml.jackson.datatype</groupId>
-            <artifactId>jackson-datatype-jdk8</artifactId>
-            <version>2.21.2</version>
+            <version>2.19.0</version>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -113,7 +113,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.19.0</version>
+            <version>2.21.2</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-jdk8</artifactId>
+            <version>2.21.2</version>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/src/main/java/com/octopus/openfeature/provider/FeatureToggleEvaluation.java
+++ b/src/main/java/com/octopus/openfeature/provider/FeatureToggleEvaluation.java
@@ -10,17 +10,17 @@ import java.util.Optional;
 class FeatureToggleEvaluation {
     private final String slug;
     private final boolean isEnabled;
-    private final Optional<String> evaluationKey;
-    private final Optional<List<Segment>> segments;
-    private final Optional<Integer> clientRolloutPercentage;
+    private final String evaluationKey;
+    private final List<Segment> segments;
+    private final Integer clientRolloutPercentage;
 
     @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
     FeatureToggleEvaluation(
             @JsonProperty(value = "slug", required = true) String slug,
             @JsonProperty(value = "isEnabled", required = true) boolean isEnabled,
-            @JsonProperty("evaluationKey") Optional<String> evaluationKey,
-            @JsonProperty("segments") Optional<List<Segment>> segments,
-            @JsonProperty("clientRolloutPercentage") Optional<Integer> clientRolloutPercentage
+            @JsonProperty("evaluationKey") String evaluationKey,
+            @JsonProperty("segments") List<Segment> segments,
+            @JsonProperty("clientRolloutPercentage") Integer clientRolloutPercentage
     ) {
         this.slug = slug;
         this.isEnabled = isEnabled;
@@ -39,18 +39,18 @@ class FeatureToggleEvaluation {
     }
 
     public Optional<String> getEvaluationKey() {
-        return evaluationKey;
+        return Optional.ofNullable(evaluationKey);
     }
 
     public Optional<List<Segment>> getSegments() {
-        return segments.map(Collections::unmodifiableList);
+        return segments == null ? Optional.empty() : Optional.of(Collections.unmodifiableList(segments));
     }
 
     public boolean hasSegments() {
-        return segments != null && segments.isPresent() && !segments.get().isEmpty();
+        return segments != null && !segments.isEmpty();
     }
 
     public Optional<Integer> getClientRolloutPercentage() {
-        return clientRolloutPercentage;
+        return Optional.ofNullable(clientRolloutPercentage);
     }
 }

--- a/src/main/java/com/octopus/openfeature/provider/FeatureToggleEvaluation.java
+++ b/src/main/java/com/octopus/openfeature/provider/FeatureToggleEvaluation.java
@@ -4,34 +4,30 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.Collections;
-import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 class FeatureToggleEvaluation {
-    private final String name;
     private final String slug;
     private final boolean isEnabled;
-    private final List<Segment> segments;
+    private final Optional<String> evaluationKey;
+    private final Optional<List<Segment>> segments;
+    private final Optional<Integer> clientRolloutPercentage;
 
     @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
     FeatureToggleEvaluation(
-        @JsonProperty("name") String name,
-        @JsonProperty("slug") String slug,
-        @JsonProperty("isEnabled") boolean isEnabled,
-        @JsonProperty("segments") List<Segment> segments
+            @JsonProperty(value = "slug", required = true) String slug,
+            @JsonProperty(value = "isEnabled", required = true) boolean isEnabled,
+            @JsonProperty("evaluationKey") Optional<String> evaluationKey,
+            @JsonProperty("segments") Optional<List<Segment>> segments,
+            @JsonProperty("clientRolloutPercentage") Optional<Integer> clientRolloutPercentage
     ) {
-        this.name = name;
         this.slug = slug;
         this.isEnabled = isEnabled;
 
-        this.segments = new ArrayList<>();
-        if (segments != null) {
-            this.segments.addAll(segments);
-        }
-    }
-
-    public String getName() {
-        return name;
+        this.evaluationKey = evaluationKey;
+        this.segments = segments;
+        this.clientRolloutPercentage = clientRolloutPercentage;
     }
 
     public String getSlug() {
@@ -42,7 +38,11 @@ class FeatureToggleEvaluation {
         return isEnabled;
     }
 
-    public List<Segment> getSegments() {
-        return Collections.unmodifiableList(segments);
+    public Optional<List<Segment>> getSegments() {
+        return segments.map(Collections::unmodifiableList);
+    }
+
+    public boolean hasSegments() {
+        return segments != null && segments.isPresent() && !segments.get().isEmpty();
     }
 }

--- a/src/main/java/com/octopus/openfeature/provider/FeatureToggleEvaluation.java
+++ b/src/main/java/com/octopus/openfeature/provider/FeatureToggleEvaluation.java
@@ -38,11 +38,19 @@ class FeatureToggleEvaluation {
         return isEnabled;
     }
 
+    public Optional<String> getEvaluationKey() {
+        return evaluationKey;
+    }
+
     public Optional<List<Segment>> getSegments() {
         return segments.map(Collections::unmodifiableList);
     }
 
     public boolean hasSegments() {
         return segments != null && segments.isPresent() && !segments.get().isEmpty();
+    }
+
+    public Optional<Integer> getClientRolloutPercentage() {
+        return clientRolloutPercentage;
     }
 }

--- a/src/main/java/com/octopus/openfeature/provider/FeatureToggleEvaluation.java
+++ b/src/main/java/com/octopus/openfeature/provider/FeatureToggleEvaluation.java
@@ -42,7 +42,7 @@ class FeatureToggleEvaluation {
     }
 
     public Optional<List<Segment>> getSegments() {
-        return segments == null ? Optional.empty() : Optional.of(segments);
+        return Optional.ofNullable(segments);
     }
 
     public boolean hasSegments() {

--- a/src/main/java/com/octopus/openfeature/provider/FeatureToggleEvaluation.java
+++ b/src/main/java/com/octopus/openfeature/provider/FeatureToggleEvaluation.java
@@ -3,7 +3,6 @@ package com.octopus.openfeature.provider;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
@@ -26,7 +25,7 @@ class FeatureToggleEvaluation {
         this.isEnabled = isEnabled;
 
         this.evaluationKey = evaluationKey;
-        this.segments = segments;
+        this.segments = segments == null ? null : List.copyOf(segments);
         this.clientRolloutPercentage = clientRolloutPercentage;
     }
 
@@ -43,7 +42,7 @@ class FeatureToggleEvaluation {
     }
 
     public Optional<List<Segment>> getSegments() {
-        return segments == null ? Optional.empty() : Optional.of(Collections.unmodifiableList(segments));
+        return segments == null ? Optional.empty() : Optional.of(segments);
     }
 
     public boolean hasSegments() {

--- a/src/main/java/com/octopus/openfeature/provider/OctopusClient.java
+++ b/src/main/java/com/octopus/openfeature/provider/OctopusClient.java
@@ -83,7 +83,7 @@ class OctopusClient {
     
     private URI getManifestURI() {
         try {
-            return new URL(config.getServerUri().toURL(), "/api/featuretoggles/v3/").toURI();
+            return new URL(config.getServerUri().toURL(), "/api/toggles/evaluations/v3/").toURI();
         } catch (MalformedURLException | URISyntaxException ignored) // we know this URL is well-formed
         { }
         return null;

--- a/src/main/java/com/octopus/openfeature/provider/OctopusClient.java
+++ b/src/main/java/com/octopus/openfeature/provider/OctopusClient.java
@@ -1,7 +1,6 @@
 package com.octopus.openfeature.provider;
 
 import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -65,7 +64,7 @@ class OctopusClient {
                 logger.log(System.Logger.Level.WARNING,String.format("Feature toggle response from %s did not contain expected ContentHash header", manifestURI.toString()));      
                 return null;
             }
-            List<FeatureToggleEvaluation> evaluations = OctopusObjectMapper.INSTANCE.readValue(httpResponse.body(), new TypeReference<List<FeatureToggleEvaluation>>(){}); 
+            List<FeatureToggleEvaluation> evaluations = OctopusObjectMapper.INSTANCE.readValue(httpResponse.body(), new TypeReference<>(){});
             return new FeatureToggles(evaluations, Base64.getDecoder().decode(contentHashHeader.get()));
         } catch (Exception e) {
             logger.log(System.Logger.Level.WARNING, "Unable to query Octopus Feature Toggle service", e);
@@ -89,10 +88,6 @@ class OctopusClient {
         return null;
     }
     
-    private Boolean isSuccessStatusCode(int statusCode) {
-        return statusCode >= 200 && statusCode < 300;
-    }
-
     // This class needs to be static to allow deserialization
     private static class FeatureToggleCheckResponse {
        public byte[] contentHash;

--- a/src/main/java/com/octopus/openfeature/provider/OctopusContext.java
+++ b/src/main/java/com/octopus/openfeature/provider/OctopusContext.java
@@ -4,7 +4,6 @@ import dev.openfeature.sdk.*;
 import dev.openfeature.sdk.exceptions.FlagNotFoundError;
 
 import java.util.List;
-import java.util.Map;
 
 import static java.util.stream.Collectors.groupingBy;
 
@@ -31,9 +30,9 @@ class OctopusContext {
         if (toggleValue == null) {
            throw new FlagNotFoundError(); 
         }
-        
+
         // if the toggle is disabled, or if it has no segments, then we don't need to evaluate dynamically 
-        if (!toggleValue.isEnabled() || toggleValue.getSegments().isEmpty()) {
+        if (!toggleValue.isEnabled() || !toggleValue.hasSegments()) {
             return ProviderEvaluation.<Boolean>builder()
                     .value(toggleValue.isEnabled())
                     .reason(Reason.DEFAULT.toString())
@@ -43,12 +42,12 @@ class OctopusContext {
         // If the toggle is enabled and has segments configured, then we need to evaluate dynamically, 
         // checking the context matches the segments
         return ProviderEvaluation.<Boolean>builder()
-                .value(MatchesSegment(evaluationContext, toggleValue.getSegments()))
+                .value(matchesSegment(evaluationContext, toggleValue.getSegments().orElseThrow())) // checked in hasSegments
                 .reason(Reason.TARGETING_MATCH.toString())
                 .build();
     }
 
-    private Boolean MatchesSegment(EvaluationContext evaluationContext, List<Segment> segments) {
+    private Boolean matchesSegment(EvaluationContext evaluationContext, List<Segment> segments) {
         if (evaluationContext == null) {
             return false;
         }

--- a/src/main/java/com/octopus/openfeature/provider/OctopusContext.java
+++ b/src/main/java/com/octopus/openfeature/provider/OctopusContext.java
@@ -19,8 +19,10 @@ class OctopusContext {
     static OctopusContext empty() {
         return new OctopusContext(new FeatureToggles(List.of(), new byte[0]));
     }
-    
-    byte[] getContentHash() { return featureToggles.getContentHash(); }
+
+    byte[] getContentHash() {
+        return featureToggles.getContentHash();
+    }
 
     ProviderEvaluation<Boolean> evaluate(String slug, Boolean defaultValue, EvaluationContext evaluationContext) {
         // find the feature toggle matching the slug
@@ -28,23 +30,41 @@ class OctopusContext {
 
         // this exception will be handled by OpenFeature, and the default value will be used
         if (toggleValue == null) {
-           throw new FlagNotFoundError(); 
+            throw new FlagNotFoundError();
         }
 
-        // if the toggle is disabled, or if it has no segments, then we don't need to evaluate dynamically 
+        if (missingRequiredPropertiesForClientSideEvaluation(toggleValue)) {
+            return ProviderEvaluation.<Boolean>builder()
+                    .value(defaultValue)
+                    .errorCode(ErrorCode.PARSE_ERROR)
+                    .errorMessage("Feature toggle " + toggleValue.getSlug() + " is missing necessary information for client-side evaluation.")
+                    .build();
+        }
+
+        // if the toggle is disabled, or if it has no segments, then we don't need to evaluate dynamically
         if (!toggleValue.isEnabled() || !toggleValue.hasSegments()) {
             return ProviderEvaluation.<Boolean>builder()
                     .value(toggleValue.isEnabled())
                     .reason(Reason.DEFAULT.toString())
                     .build();
         }
-        
-        // If the toggle is enabled and has segments configured, then we need to evaluate dynamically, 
+
+        // If the toggle is enabled and has segments configured, then we need to evaluate dynamically,
         // checking the context matches the segments
         return ProviderEvaluation.<Boolean>builder()
                 .value(matchesSegment(evaluationContext, toggleValue.getSegments().orElseThrow())) // checked in hasSegments
                 .reason(Reason.TARGETING_MATCH.toString())
                 .build();
+    }
+
+    private boolean missingRequiredPropertiesForClientSideEvaluation(FeatureToggleEvaluation toggle) {
+        if (!toggle.isEnabled()) {
+            return false;
+        }
+
+        return toggle.getClientRolloutPercentage().isEmpty()
+                || toggle.getEvaluationKey().isEmpty()
+                || toggle.getSegments().isEmpty();
     }
 
     private Boolean matchesSegment(EvaluationContext evaluationContext, List<Segment> segments) {

--- a/src/main/java/com/octopus/openfeature/provider/OctopusContext.java
+++ b/src/main/java/com/octopus/openfeature/provider/OctopusContext.java
@@ -2,6 +2,7 @@ package com.octopus.openfeature.provider;
 
 import dev.openfeature.sdk.*;
 import dev.openfeature.sdk.exceptions.FlagNotFoundError;
+import dev.openfeature.sdk.exceptions.ParseError;
 
 import java.util.List;
 
@@ -34,11 +35,7 @@ class OctopusContext {
         }
 
         if (missingRequiredPropertiesForClientSideEvaluation(toggleValue)) {
-            return ProviderEvaluation.<Boolean>builder()
-                    .value(defaultValue)
-                    .errorCode(ErrorCode.PARSE_ERROR)
-                    .errorMessage("Feature toggle " + toggleValue.getSlug() + " is missing necessary information for client-side evaluation.")
-                    .build();
+            throw new ParseError("Feature toggle " + toggleValue.getSlug() + " is missing necessary information for client-side evaluation.");
         }
 
         // if the toggle is disabled, or if it has no segments, then we don't need to evaluate dynamically
@@ -57,14 +54,14 @@ class OctopusContext {
                 .build();
     }
 
-    private boolean missingRequiredPropertiesForClientSideEvaluation(FeatureToggleEvaluation toggle) {
-        if (!toggle.isEnabled()) {
+    private boolean missingRequiredPropertiesForClientSideEvaluation(FeatureToggleEvaluation evaluation) {
+        if (!evaluation.isEnabled()) {
             return false;
         }
 
-        return toggle.getClientRolloutPercentage().isEmpty()
-                || toggle.getEvaluationKey().isEmpty()
-                || toggle.getSegments().isEmpty();
+        return evaluation.getClientRolloutPercentage().isEmpty()
+                || evaluation.getEvaluationKey().isEmpty()
+                || evaluation.getSegments().isEmpty();
     }
 
     private Boolean matchesSegment(EvaluationContext evaluationContext, List<Segment> segments) {

--- a/src/main/java/com/octopus/openfeature/provider/OctopusObjectMapper.java
+++ b/src/main/java/com/octopus/openfeature/provider/OctopusObjectMapper.java
@@ -4,10 +4,12 @@ import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.json.JsonMapper;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 
 class OctopusObjectMapper {
     static final ObjectMapper INSTANCE = JsonMapper.builder()
             .enable(MapperFeature.ACCEPT_CASE_INSENSITIVE_PROPERTIES)
             .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
-            .build();
+            .build()
+            .registerModule(new Jdk8Module()); // required for Optional<T>
 }

--- a/src/main/java/com/octopus/openfeature/provider/OctopusObjectMapper.java
+++ b/src/main/java/com/octopus/openfeature/provider/OctopusObjectMapper.java
@@ -4,12 +4,10 @@ import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.json.JsonMapper;
-import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 
 class OctopusObjectMapper {
     static final ObjectMapper INSTANCE = JsonMapper.builder()
             .enable(MapperFeature.ACCEPT_CASE_INSENSITIVE_PROPERTIES)
             .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
-            .build()
-            .registerModule(new Jdk8Module()); // required for Optional<T>
+            .build();
 }

--- a/src/test/java/com/octopus/openfeature/provider/FeatureToggleEvaluationDeserializationTests.java
+++ b/src/test/java/com/octopus/openfeature/provider/FeatureToggleEvaluationDeserializationTests.java
@@ -20,8 +20,8 @@ class FeatureToggleEvaluationDeserializationTests {
         return getClass().getResourceAsStream(name);
     }
 
-    private void assertSegmentsContain(Optional<List<Segment>> segments, Segment expected) {
-        assertThat(segments.orElseThrow()).usingRecursiveFieldByFieldElementComparator().contains(expected);
+    private void assertSegmentsContain(List<Segment> segments, Segment... expected) {
+        assertThat(segments).usingRecursiveFieldByFieldElementComparator().contains(expected);
     }
 
     @Test
@@ -52,10 +52,13 @@ class FeatureToggleEvaluationDeserializationTests {
         FeatureToggleEvaluation result = objectMapper.readValue(
                 resource("toggle-with-segments.json"), FeatureToggleEvaluation.class);
 
-        assertThat(result.getSegments().orElseThrow()).hasSize(2);
+        var segments = result.getSegments().orElseThrow();
+
+        assertThat(segments).hasSize(2);
         assertSegmentsContain(
-                result.getSegments(),
-                new Segment("license-type", "free")
+                segments,
+                new Segment("license-type", "free"),
+                new Segment("country", "au")
         );
     }
 
@@ -85,13 +88,13 @@ class FeatureToggleEvaluationDeserializationTests {
         assertThat(result).hasSize(3);
         assertThat(result.get(0).getSlug()).isEqualTo("feature-a");
         assertThat(result.get(0).isEnabled()).isTrue();
-        assertSegmentsContain(result.get(0).getSegments(), new Segment("license-type", "free"));
+        assertSegmentsContain(result.get(0).getSegments().orElseThrow(), new Segment("license-type", "free"));
         assertThat(result.get(1).getSlug()).isEqualTo("feature-b");
         assertThat(result.get(1).isEnabled()).isTrue();
-        assertSegmentsContain(result.get(1).getSegments(), new Segment("plan", "enterprise"));
+        assertSegmentsContain(result.get(1).getSegments().orElseThrow(), new Segment("plan", "enterprise"));
         assertThat(result.get(2).getSlug()).isEqualTo("feature-c");
         assertThat(result.get(2).isEnabled()).isTrue();
-        assertSegmentsContain(result.get(2).getSegments(), new Segment("country", "au"));
+        assertSegmentsContain(result.get(2).getSegments().orElseThrow(), new Segment("country", "au"));
     }
 
     @Test
@@ -122,6 +125,6 @@ class FeatureToggleEvaluationDeserializationTests {
 
         assertThat(result.getSlug()).isEqualTo("my-feature");
         assertThat(result.isEnabled()).isTrue();
-        assertSegmentsContain(result.getSegments(), new Segment("license-type", "free"));
+        assertSegmentsContain(result.getSegments().orElseThrow(), new Segment("license-type", "free"));
     }
 }

--- a/src/test/java/com/octopus/openfeature/provider/FeatureToggleEvaluationDeserializationTests.java
+++ b/src/test/java/com/octopus/openfeature/provider/FeatureToggleEvaluationDeserializationTests.java
@@ -7,7 +7,7 @@ import org.junit.jupiter.api.Test;
 
 import java.io.InputStream;
 import java.util.List;
-import java.util.Map;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -20,15 +20,14 @@ class FeatureToggleEvaluationDeserializationTests {
         return getClass().getResourceAsStream(name);
     }
 
-    private void assertSegmentsContain(List<Segment> segments, Segment... expected) {
-        assertThat(segments).usingRecursiveFieldByFieldElementComparator().contains(expected);
+    private void assertSegmentsContain(Optional<List<Segment>> segments, Segment expected) {
+        assertThat(segments.orElseThrow()).usingRecursiveFieldByFieldElementComparator().contains(expected);
     }
 
     @Test
     void shouldDeserializeEnabledToggle() throws Exception {
         FeatureToggleEvaluation result = objectMapper.readValue(resource("toggle-enabled-no-segments.json"), FeatureToggleEvaluation.class);
 
-        assertThat(result.getName()).isEqualTo("My Feature");
         assertThat(result.getSlug()).isEqualTo("my-feature");
         assertThat(result.isEnabled()).isTrue();
         assertThat(result.getSegments()).isEmpty();
@@ -53,10 +52,10 @@ class FeatureToggleEvaluationDeserializationTests {
         FeatureToggleEvaluation result = objectMapper.readValue(
                 resource("toggle-with-segments.json"), FeatureToggleEvaluation.class);
 
-        assertThat(result.getSegments()).hasSize(2);
-        assertSegmentsContain(result.getSegments(),
-                new Segment("license-type", "free"),
-                new Segment("country", "au")
+        assertThat(result.getSegments().orElseThrow()).hasSize(2);
+        assertSegmentsContain(
+                result.getSegments(),
+                new Segment("license-type", "free")
         );
     }
 
@@ -121,7 +120,6 @@ class FeatureToggleEvaluationDeserializationTests {
         FeatureToggleEvaluation result = objectMapper.readValue(
                 resource("toggle-with-extraneous-properties.json"), FeatureToggleEvaluation.class);
 
-        assertThat(result.getName()).isEqualTo("My Feature");
         assertThat(result.getSlug()).isEqualTo("my-feature");
         assertThat(result.isEnabled()).isTrue();
         assertSegmentsContain(result.getSegments(), new Segment("license-type", "free"));

--- a/src/test/java/com/octopus/openfeature/provider/FeatureToggleEvaluationDeserializationTests.java
+++ b/src/test/java/com/octopus/openfeature/provider/FeatureToggleEvaluationDeserializationTests.java
@@ -30,7 +30,10 @@ class FeatureToggleEvaluationDeserializationTests {
 
         assertThat(result.getSlug()).isEqualTo("my-feature");
         assertThat(result.isEnabled()).isTrue();
-        assertThat(result.getSegments()).isEmpty();
+        assertThat(result.getEvaluationKey()).hasValue("eval-key-1");
+        assertThat(result.getSegments()).isPresent();
+        assertThat(result.getSegments().orElseThrow()).isEmpty();
+        assertThat(result.getClientRolloutPercentage()).hasValue(100);
     }
 
     @Test
@@ -38,13 +41,16 @@ class FeatureToggleEvaluationDeserializationTests {
         FeatureToggleEvaluation result = objectMapper.readValue(resource("toggle-disabled.json"), FeatureToggleEvaluation.class);
 
         assertThat(result.isEnabled()).isFalse();
+        assertThat(result.getEvaluationKey()).isEmpty();
+        assertThat(result.getSegments()).isEmpty();
+        assertThat(result.getClientRolloutPercentage()).isEmpty();
     }
 
     @Test
     void shouldDeserializeToggleWithMissingSegmentsField() throws Exception {
         FeatureToggleEvaluation result = objectMapper.readValue(resource("toggle-missing-segments.json"), FeatureToggleEvaluation.class);
 
-        assertThat(result.getSegments()).isNotNull().isEmpty();
+        assertThat(result.getSegments()).isEmpty();
     }
 
     @Test

--- a/src/test/java/com/octopus/openfeature/provider/OctopusContextTests.java
+++ b/src/test/java/com/octopus/openfeature/provider/OctopusContextTests.java
@@ -4,24 +4,22 @@ import dev.openfeature.sdk.EvaluationContext;
 import dev.openfeature.sdk.MutableContext;
 import dev.openfeature.sdk.Reason;
 import dev.openfeature.sdk.exceptions.FlagNotFoundError;
+import net.bytebuddy.description.annotation.AnnotationList;
 import org.junit.jupiter.api.*;
 
-import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
+import java.util.*;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 
 class OctopusContextTests {
-    
+
     private static final FeatureToggles sampleFeatureToggles = new FeatureToggles(
             Arrays.asList(
-                    new FeatureToggleEvaluation("enabled-feature", true, null, null, null),
-                    new FeatureToggleEvaluation( "disabled-feature", false, null, null, null),
-                    new FeatureToggleEvaluation( "feature-with-segments", true, null, Optional.of(Arrays.asList(new Segment("license-type", "free"), new Segment("country", "au"))), null)
+                    new FeatureToggleEvaluation("enabled-feature", true, Optional.of(UUID.randomUUID().toString()), Optional.of(Collections.emptyList()), Optional.of(100)),
+                    new FeatureToggleEvaluation("disabled-feature", false, Optional.empty(), Optional.empty(), Optional.empty()),
+                    new FeatureToggleEvaluation("feature-with-segments", true, Optional.of(UUID.randomUUID().toString()), Optional.of(Arrays.asList(new Segment("license-type", "free"), new Segment("country", "au"))), Optional.of(100))
             ),
             new byte[0]
     );
@@ -30,11 +28,11 @@ class OctopusContextTests {
     @Test
     void shouldEvaluateToTrueIfFeatureToggleIsPresentAndEnabled() {
         var subject = new OctopusContext(sampleFeatureToggles);
-        var result = subject.evaluate("enabled-feature", false, null); 
-        
+        var result = subject.evaluate("enabled-feature", false, null);
+
         assertThat(result.getValue()).isTrue();
     }
-    
+
     @Test
     void keyShouldBeCaseInsensitiveWhenEvaluating() {
         var subject = new OctopusContext(sampleFeatureToggles);
@@ -42,27 +40,27 @@ class OctopusContextTests {
 
         assertThat(result.getValue()).isTrue();
     }
-    
+
     @Test
     void shouldEvaluateToFalseIfFeatureToggleIsPresentAndDisabled() {
         var subject = new OctopusContext(sampleFeatureToggles);
-        var result = subject.evaluate("disabled-feature", false, null); 
-        
+        var result = subject.evaluate("disabled-feature", false, null);
+
         assertThat(result.getValue()).isFalse();
     }
-    
+
     @Test
     void shouldThrowFlagNotFoundErrorIfFeatureToggleIsNotFound() {
         var defaultValue = false;
         var subject = new OctopusContext(sampleFeatureToggles);
         assertThrows(FlagNotFoundError.class, () -> subject.evaluate("key-not-present", defaultValue, null));
-    } 
-    
+    }
+
     @TestFactory
     Iterable<DynamicTest> shouldCorrectlyDynamicallyEvaluateSegmentsWhenSupplied() {
         return Arrays.asList(
-                
-                evaluationTest("no-segments", "enabled-feature", 
+
+                evaluationTest("no-segments", "enabled-feature",
                         buildEvaluationContext(List.of(
                                 Map.entry("user-id", "123456")
                         )), true, Reason.DEFAULT.toString()),
@@ -71,7 +69,7 @@ class OctopusContextTests {
                         buildEvaluationContext(List.of()
                         ), false, Reason.TARGETING_MATCH.toString()),
 
-                evaluationTest("all-segments-match", "feature-with-segments", 
+                evaluationTest("all-segments-match", "feature-with-segments",
                         buildEvaluationContext(Arrays.asList(
                                 Map.entry("license-type", "free"), Map.entry("country", "au"))
                         ), true, Reason.TARGETING_MATCH.toString()),
@@ -92,23 +90,23 @@ class OctopusContextTests {
                         ), false, Reason.TARGETING_MATCH.toString())
         );
     }
-    
-    private DynamicTest evaluationTest(String testName, String featureToggleKey, EvaluationContext evaluationContext, 
+
+    private DynamicTest evaluationTest(String testName, String featureToggleKey, EvaluationContext evaluationContext,
                                        boolean expectedResult, String expectedReason) {
-       return DynamicTest.dynamicTest(testName, () -> {
-           var subject = new OctopusContext(sampleFeatureToggles);
-           var result = subject.evaluate(featureToggleKey, false, evaluationContext); 
-           assertThat(result.getValue()).isEqualTo(expectedResult);
-           assertThat(result.getReason()).isEqualTo(expectedReason);
-       }); 
+        return DynamicTest.dynamicTest(testName, () -> {
+            var subject = new OctopusContext(sampleFeatureToggles);
+            var result = subject.evaluate(featureToggleKey, false, evaluationContext);
+            assertThat(result.getValue()).isEqualTo(expectedResult);
+            assertThat(result.getReason()).isEqualTo(expectedReason);
+        });
     }
-    
+
     private EvaluationContext buildEvaluationContext(List<Map.Entry<String, String>> entries) {
         var context = new MutableContext();
         entries.forEach(entry -> {
             context.add(entry.getKey(), entry.getValue());
         });
         return context;
-    } 
-    
+    }
+
 }

--- a/src/test/java/com/octopus/openfeature/provider/OctopusContextTests.java
+++ b/src/test/java/com/octopus/openfeature/provider/OctopusContextTests.java
@@ -4,7 +4,7 @@ import dev.openfeature.sdk.EvaluationContext;
 import dev.openfeature.sdk.MutableContext;
 import dev.openfeature.sdk.Reason;
 import dev.openfeature.sdk.exceptions.FlagNotFoundError;
-import net.bytebuddy.description.annotation.AnnotationList;
+import dev.openfeature.sdk.exceptions.ParseError;
 import org.junit.jupiter.api.*;
 
 import java.util.*;
@@ -54,6 +54,46 @@ class OctopusContextTests {
         var defaultValue = false;
         var subject = new OctopusContext(sampleFeatureToggles);
         assertThrows(FlagNotFoundError.class, () -> subject.evaluate("key-not-present", defaultValue, null));
+    }
+
+    @Test
+    void shouldThrowParseErrorWhenEnabledToggleIsMissingEvaluationKey() {
+        var toggles = new FeatureToggles(
+                List.of(new FeatureToggleEvaluation("feature-a", true, null, Collections.emptyList(), 100)),
+                new byte[0]
+        );
+        var subject = new OctopusContext(toggles);
+        assertThrows(ParseError.class, () -> subject.evaluate("feature-a", false, null));
+    }
+
+    @Test
+    void shouldThrowParseErrorWhenEnabledToggleIsMissingSegments() {
+        var toggles = new FeatureToggles(
+                List.of(new FeatureToggleEvaluation("feature-b", true, "evaluation-key", null, 100)),
+                new byte[0]
+        );
+        var subject = new OctopusContext(toggles);
+        assertThrows(ParseError.class, () -> subject.evaluate("feature-b", false, null));
+    }
+
+    @Test
+    void shouldThrowParseErrorWhenEnabledToggleIsMissingClientRolloutPercentage() {
+        var toggles = new FeatureToggles(
+                List.of(new FeatureToggleEvaluation("feature-c", true, "evaluation-key", Collections.emptyList(), null)),
+                new byte[0]
+        );
+        var subject = new OctopusContext(toggles);
+        assertThrows(ParseError.class, () -> subject.evaluate("feature-c", false, null));
+    }
+
+    @Test
+    void shouldThrowParseErrorWhenEnabledToggleIsMissingAllClientEvaluationFields() {
+        var toggles = new FeatureToggles(
+                List.of(new FeatureToggleEvaluation("feature-d", true, null, null, null)),
+                new byte[0]
+        );
+        var subject = new OctopusContext(toggles);
+        assertThrows(ParseError.class, () -> subject.evaluate("feature-d", true, null));
     }
 
     @TestFactory

--- a/src/test/java/com/octopus/openfeature/provider/OctopusContextTests.java
+++ b/src/test/java/com/octopus/openfeature/provider/OctopusContextTests.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.*;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -18,9 +19,9 @@ class OctopusContextTests {
     
     private static final FeatureToggles sampleFeatureToggles = new FeatureToggles(
             Arrays.asList(
-                    new FeatureToggleEvaluation("Enabled Feature", "enabled-feature", true, null),
-                    new FeatureToggleEvaluation("Disabled Feature", "disabled-feature", false, null),
-                    new FeatureToggleEvaluation("Feature With Segments", "feature-with-segments", true, Arrays.asList(new Segment("license-type", "free"), new Segment("country", "au")) )
+                    new FeatureToggleEvaluation("enabled-feature", true, null, null, null),
+                    new FeatureToggleEvaluation( "disabled-feature", false, null, null, null),
+                    new FeatureToggleEvaluation( "feature-with-segments", true, null, Optional.of(Arrays.asList(new Segment("license-type", "free"), new Segment("country", "au"))), null)
             ),
             new byte[0]
     );

--- a/src/test/java/com/octopus/openfeature/provider/OctopusContextTests.java
+++ b/src/test/java/com/octopus/openfeature/provider/OctopusContextTests.java
@@ -17,9 +17,9 @@ class OctopusContextTests {
 
     private static final FeatureToggles sampleFeatureToggles = new FeatureToggles(
             Arrays.asList(
-                    new FeatureToggleEvaluation("enabled-feature", true, Optional.of(UUID.randomUUID().toString()), Optional.of(Collections.emptyList()), Optional.of(100)),
-                    new FeatureToggleEvaluation("disabled-feature", false, Optional.empty(), Optional.empty(), Optional.empty()),
-                    new FeatureToggleEvaluation("feature-with-segments", true, Optional.of(UUID.randomUUID().toString()), Optional.of(Arrays.asList(new Segment("license-type", "free"), new Segment("country", "au"))), Optional.of(100))
+                    new FeatureToggleEvaluation("enabled-feature", true, UUID.randomUUID().toString(), Collections.emptyList(), 100),
+                    new FeatureToggleEvaluation("disabled-feature", false, null, null, null),
+                    new FeatureToggleEvaluation("feature-with-segments", true, UUID.randomUUID().toString(), Arrays.asList(new Segment("license-type", "free"), new Segment("country", "au")), 100)
             ),
             new byte[0]
     );

--- a/src/test/java/com/octopus/openfeature/provider/OctopusContextTests.java
+++ b/src/test/java/com/octopus/openfeature/provider/OctopusContextTests.java
@@ -63,7 +63,8 @@ class OctopusContextTests {
                 new byte[0]
         );
         var subject = new OctopusContext(toggles);
-        assertThrows(ParseError.class, () -> subject.evaluate("feature-a", false, null));
+        var ex = assertThrows(ParseError.class, () -> subject.evaluate("feature-a", false, null));
+        assertThat(ex.getMessage()).contains("feature-a");
     }
 
     @Test
@@ -73,7 +74,8 @@ class OctopusContextTests {
                 new byte[0]
         );
         var subject = new OctopusContext(toggles);
-        assertThrows(ParseError.class, () -> subject.evaluate("feature-b", false, null));
+        var ex = assertThrows(ParseError.class, () -> subject.evaluate("feature-b", false, null));
+        assertThat(ex.getMessage()).contains("feature-b");
     }
 
     @Test
@@ -83,7 +85,8 @@ class OctopusContextTests {
                 new byte[0]
         );
         var subject = new OctopusContext(toggles);
-        assertThrows(ParseError.class, () -> subject.evaluate("feature-c", false, null));
+        var ex = assertThrows(ParseError.class, () -> subject.evaluate("feature-c", false, null));
+        assertThat(ex.getMessage()).contains("feature-c");
     }
 
     @Test
@@ -93,7 +96,8 @@ class OctopusContextTests {
                 new byte[0]
         );
         var subject = new OctopusContext(toggles);
-        assertThrows(ParseError.class, () -> subject.evaluate("feature-d", true, null));
+        var ex = assertThrows(ParseError.class, () -> subject.evaluate("feature-d", true, null));
+        assertThat(ex.getMessage()).contains("feature-d");
     }
 
     @TestFactory

--- a/src/test/java/com/octopus/openfeature/provider/Server.java
+++ b/src/test/java/com/octopus/openfeature/provider/Server.java
@@ -42,7 +42,7 @@ class Server {
      */
     String configure(String responseJson) {
         String token = UUID.randomUUID().toString();
-        wireMock.stubFor(get(urlPathEqualTo("/api/featuretoggles/v3/"))
+        wireMock.stubFor(get(urlPathEqualTo("/api/toggles/evaluations/v3/"))
             .withHeader("Authorization", equalTo("Bearer " + token))
             .willReturn(aResponse()
                 .withStatus(200)

--- a/src/test/java/com/octopus/openfeature/provider/SpecificationTests.java
+++ b/src/test/java/com/octopus/openfeature/provider/SpecificationTests.java
@@ -12,6 +12,7 @@ import dev.openfeature.sdk.*;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -49,6 +50,7 @@ class SpecificationTests {
 
     @ParameterizedTest(name = "[{0}] {1}")
     @MethodSource("fixtureTestCases")
+    @Disabled("Requires either old endpoint to be used, or client rollout percentage to be implemented")
     void evaluate(String fileName, String description, String responseJson, FixtureCase testCase) {
         String token = server.configure(responseJson);
         OctopusConfiguration config = new OctopusConfiguration(token);

--- a/src/test/resources/com/octopus/openfeature/provider/toggle-disabled.json
+++ b/src/test/resources/com/octopus/openfeature/provider/toggle-disabled.json
@@ -1,6 +1,4 @@
 {
-  "name": "My Feature",
   "slug": "my-feature",
-  "isEnabled": false,
-  "segments": null
+  "isEnabled": false
 }

--- a/src/test/resources/com/octopus/openfeature/provider/toggle-enabled-no-segments.json
+++ b/src/test/resources/com/octopus/openfeature/provider/toggle-enabled-no-segments.json
@@ -1,6 +1,7 @@
 {
-  "name": "My Feature",
   "slug": "my-feature",
   "isEnabled": true,
-  "segments": null
+  "evaluationKey": "eval-key-1",
+  "segments": [],
+  "clientRolloutPercentage": 100
 }

--- a/src/test/resources/com/octopus/openfeature/provider/toggle-list.json
+++ b/src/test/resources/com/octopus/openfeature/provider/toggle-list.json
@@ -1,14 +1,13 @@
 [
   {
-    "name": "Feature A",
     "slug": "feature-a",
     "isEnabled": true,
-    "segments": null
+    "evaluationKey": "eval-key-a",
+    "segments": [],
+    "clientRolloutPercentage": 100
   },
   {
-    "name": "Feature B",
     "slug": "feature-b",
-    "isEnabled": false,
-    "segments": null
+    "isEnabled": false
   }
 ]

--- a/src/test/resources/com/octopus/openfeature/provider/toggle-missing-segments.json
+++ b/src/test/resources/com/octopus/openfeature/provider/toggle-missing-segments.json
@@ -1,5 +1,6 @@
 {
-  "name": "My Feature",
   "slug": "my-feature",
-  "isEnabled": true
+  "isEnabled": true,
+  "evaluationKey": "eval-key-1",
+  "clientRolloutPercentage": 100
 }

--- a/src/test/resources/com/octopus/openfeature/provider/toggle-segment-missing-key-and-value.json
+++ b/src/test/resources/com/octopus/openfeature/provider/toggle-segment-missing-key-and-value.json
@@ -1,8 +1,9 @@
 {
-  "name": "My Feature",
   "slug": "my-feature",
   "isEnabled": true,
+  "evaluationKey": "eval-key-1",
   "segments": [
     {}
-  ]
+  ],
+  "clientRolloutPercentage": 100
 }

--- a/src/test/resources/com/octopus/openfeature/provider/toggle-segment-missing-key.json
+++ b/src/test/resources/com/octopus/openfeature/provider/toggle-segment-missing-key.json
@@ -1,10 +1,11 @@
 {
-  "name": "My Feature",
   "slug": "my-feature",
   "isEnabled": true,
+  "evaluationKey": "eval-key-1",
   "segments": [
     {
       "value": "free"
     }
-  ]
+  ],
+  "clientRolloutPercentage": 100
 }

--- a/src/test/resources/com/octopus/openfeature/provider/toggle-segment-missing-value.json
+++ b/src/test/resources/com/octopus/openfeature/provider/toggle-segment-missing-value.json
@@ -1,10 +1,11 @@
 {
-  "name": "My Feature",
   "slug": "my-feature",
   "isEnabled": true,
+  "evaluationKey": "eval-key-1",
   "segments": [
     {
       "key": "license-type"
     }
-  ]
+  ],
+  "clientRolloutPercentage": 100
 }

--- a/src/test/resources/com/octopus/openfeature/provider/toggle-with-extraneous-properties.json
+++ b/src/test/resources/com/octopus/openfeature/provider/toggle-with-extraneous-properties.json
@@ -1,7 +1,7 @@
 {
-  "name": "My Feature",
   "slug": "my-feature",
   "isEnabled": true,
+  "evaluationKey": "eval-key-1",
   "segments": [
     {
       "key": "license-type",
@@ -9,6 +9,7 @@
       "more": "data"
     }
   ],
+  "clientRolloutPercentage": 100,
   "foo": "bar",
   "qux": 123,
   "wux": {

--- a/src/test/resources/com/octopus/openfeature/provider/toggle-with-segments.json
+++ b/src/test/resources/com/octopus/openfeature/provider/toggle-with-segments.json
@@ -1,7 +1,7 @@
 {
-  "name": "My Feature",
   "slug": "my-feature",
   "isEnabled": true,
+  "evaluationKey": "eval-key-1",
   "segments": [
     {
       "key": "license-type",
@@ -11,5 +11,6 @@
       "key": "country",
       "value": "au"
     }
-  ]
+  ],
+  "clientRolloutPercentage": 100
 }

--- a/src/test/resources/com/octopus/openfeature/provider/toggles-with-different-field-capitalisation.json
+++ b/src/test/resources/com/octopus/openfeature/provider/toggles-with-different-field-capitalisation.json
@@ -1,35 +1,38 @@
 [
   {
-    "NAME": "Feature A",
     "SLUG": "feature-a",
     "ISENABLED": true,
+    "EVALUATIONKEY": "eval-key-a",
     "SEGMENTS": [
       {
         "KEY": "license-type",
         "VALUE": "free"
       }
-    ]
+    ],
+    "CLIENTROLLOUTPERCENTAGE": 100
   },
   {
-    "Name": "Feature B",
     "Slug": "feature-b",
     "IsEnabled": true,
+    "EvaluationKey": "eval-key-b",
     "Segments": [
       {
         "Key": "plan",
         "Value": "enterprise"
       }
-    ]
+    ],
+    "ClientRolloutPercentage": 100
   },
   {
-    "nAmE": "Feature C",
     "sLuG": "feature-c",
     "iSeNaBlEd": true,
+    "eVaLuAtIoNkEy": "eval-key-c",
     "sEgMeNtS": [
       {
         "kEy": "country",
         "vAlUe": "au"
       }
-    ]
+    ],
+    "cLiEnTrOlLoUtPeRcEnTaGe": 100
   }
 ]


### PR DESCRIPTION
# Background

The client percentage rollout feature requires `ClientRolloutPercentage` and `EvaluationKey` to be included in evaluation responses. 

We were unable to add these fields to the existing `GET /featuretoggles/v3` evaluations endpoint because the Java OpenFeature provider (in this repo) was previously using Jackson with strict deserialisation (`FAIL_ON_UNKNOWN_PROPERTIES = true`). Even though we relaxed this in https://github.com/OctopusDeploy/openfeature-provider-java/pull/5, we still can't change the existing endpoint because there are deployed versions of the older serialisation configuration.

This PR updates the provider to use the new endpoint, which has the following changes compared to the old endpoint:
* The `name` field was removed
* `evaluationKey` and `clientRolloutPercentage` were added, though are only returned if `isEnabled` evaluated to `true` in the feature toggles service
* `segments` are also only returned if `isEnabled` evaluated to `true`

# Changes
* Update URI called my provider and in test WireMock server
* Updates to `FeatureToggleEvaluation` class
  * Removed `name` property and getter
  * Added `evaluationKey` and `clientRolloutPercentage` properties with `Optional` getters
  * Updated `getSegments` to `Optional` getter
  * Added `hasSegments` convenience method
* Updates to `OctopusContext` class
  * Type changes from `FeatureToggleEvaluation`
  * Added `missingRequiredPropertiesForClientSideEvaluation` check
 
# Notes for review

* While Java does not support nullable reference types (i.e. all reference fields could be `null`) we can use the `Optional<T>` type to make it explicit which getter values should be checked or defaulted.
* The new fields are not actually being used yet, but will be in the next PR.

# Testing

* All existing tests are passing, albeit with some change in test data.
* The majority of specification tests at [this commit](https://github.com/OctopusDeploy/openfeature-provider-specification/tree/cdffe1e884518bde7e43065a252ecdcbd4fb209e) pass, except those relying on the client rollout functionality. As such, I have disabled the specification tests because there isn't a commit in `OctopusDeploy/openfeature-provider-specification` that uses the new endpoint response shape that doesn't also expect the client percentage rollout feature to be implemented. This will be implemented and fully tested in the next PR, prior to the next release of this library

<img width="996" height="617" alt="Screenshot 2026-03-30 at 15 25 08" src="https://github.com/user-attachments/assets/e44127e5-3860-4fe9-b7f9-17353e9f15f4" />

