### PR TITLE
test: Add unicode test cases

### DIFF
--- a/src/test/java/com/octopus/openfeature/provider/OctopusContextTests.java
+++ b/src/test/java/com/octopus/openfeature/provider/OctopusContextTests.java
@@ -61,7 +61,7 @@ class OctopusContextTests {
     @Test
     void throwsFlagNotFound_IfFeatureIsNotContainedWithinSet() {
         var toggles = new FeatureToggles(
-                List.of(new FeatureToggleEvaluation("testfeature", true, "evaluation-key", Collections.emptyList(), 100)),
+                List.of(new FeatureToggleEvaluation("testfeature", false, "evaluation-key", Collections.emptyList(), 100)),
                 new byte[0]
         );
         var subject = new OctopusContext(toggles);
@@ -396,7 +396,17 @@ class OctopusContextTests {
                 Arguments.of("test", "az", 1),
                 Arguments.of("bucket", "j", 1),
                 Arguments.of("test", "y", 100),
-                Arguments.of("flag", "c", 100)
+                Arguments.of("flag", "c", 100),
+                Arguments.of("test-feature", "用户", 30),
+                Arguments.of("test-feature", "مستخدم", 19),
+                Arguments.of("test-feature", "ユーザー", 73),
+                Arguments.of("test-feature", "🎉", 54),
+                Arguments.of("test-feature", "café", 31),
+                Arguments.of("test-feature", "naïve", 28),
+                Arguments.of("rollout", "用户-001", 20),
+                Arguments.of("experiment-a", "пользователь", 81),
+                Arguments.of("test-feature", "사용자", 62),
+                Arguments.of("dark-launch", "テナント-001", 8)
         );
     }
 }


### PR DESCRIPTION
# Background

While [adding fractional evaluation to the TypeScript provider library](https://linear.app/octopus/issue/DEVEX-81/add-fractional-evaluation-support-to-typescript-client-library), a gap in testing was identified: correct hashing of strings containing non-Latin alphanumeric characters.

# Changes

* Added test cases for a variety of character types.
* Also updated a test that was asserting a default value where the evaluated value was the same as the default.

These align with these PRs for the other libraries:
* https://github.com/OctopusDeploy/openfeature-provider-dotnet/pull/48
* https://github.com/OctopusDeploy/openfeature-provider-ts-web/pull/49