### PR TITLE
chore: Add conventional commit title check workflow

### DIFF
--- a/.github/workflows/validate-pr-title.yml
+++ b/.github/workflows/validate-pr-title.yml
@@ -1,0 +1,22 @@
+name: Validate PR title
+
+on:
+  pull_request:
+    branches:
+      - main
+    types:
+      - opened
+      - edited
+      - reopened
+      - synchronize
+
+jobs:
+  validate-pr-title:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+
+    steps:
+      - uses: amannn/action-semantic-pull-request@v6
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## What's this? 🐦 

We plan to use Release Please in this repository to coordinate releases, based on conventional commit prefixes.

This PR add a workflow to check that a PR title contains a conventional commit message. It runs when a PR is opened/reopened/pushed-to or when the PR title/description is edited. 

The workflow is copied directly from our [`openfeature-provider-dotnet` repo](https://github.com/OctopusDeploy/openfeature-provider-dotnet/blob/main/.github/workflows/validate-pr-title.yml).

 🚩 To make this change more effective, I've also updated the repository to allow only squash merges and take the commit message for a squash merge from the PR title. 

Completes DEVEX-274
