### PR TITLE
fix: Fallback to existing evaluation context on failed refresh

### DIFF
--- a/src/main/java/com/octopus/openfeature/provider/OctopusContextProvider.java
+++ b/src/main/java/com/octopus/openfeature/provider/OctopusContextProvider.java
@@ -52,7 +52,11 @@ class OctopusContextProvider {
 
                 if (client.haveFeatureTogglesChanged(currentContext.getContentHash())) {
                     var toggles = client.getFeatureToggleEvaluationManifest();
-                    currentContext = toggles == null ? OctopusContext.empty() : new OctopusContext(toggles);
+                    if (toggles != null) {
+                        currentContext = new OctopusContext(toggles);
+                    } else {
+                        logger.log(System.Logger.Level.ERROR, "Failed to retrieve updated feature manifest. Retaining existing context which may be stale.");
+                    }
                 }
 
                 delay = config.getCacheDuration();

--- a/src/test/java/com/octopus/openfeature/provider/OctopusContextProviderTests.java
+++ b/src/test/java/com/octopus/openfeature/provider/OctopusContextProviderTests.java
@@ -1,7 +1,4 @@
 package com.octopus.openfeature.provider;
-
-import org.junit.jupiter.api.Test;
-
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -11,13 +8,15 @@ import java.util.logging.LogRecord;
 import java.util.logging.Logger;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import org.junit.jupiter.api.Test;
 
 class OctopusContextProviderTests {
 
-    static class FakeClient extends OctopusClient {
+    static class MockOctopusFeatureClient extends OctopusClient {
+
         private volatile FeatureToggles toggles;
 
-        FakeClient(FeatureToggles toggles) {
+        MockOctopusFeatureClient(FeatureToggles toggles) {
             super(null);
             this.toggles = toggles;
         }
@@ -37,7 +36,9 @@ class OctopusContextProviderTests {
         }
     }
 
-    private OctopusConfiguration fastConfig() {
+    private final OctopusConfiguration configuration = configure();
+
+    private static OctopusConfiguration configure() {
         var config = new OctopusConfiguration("token");
         config.setCacheDuration(Duration.ofMillis(100));
         return config;
@@ -45,28 +46,36 @@ class OctopusContextProviderTests {
 
     @Test
     void whenInitialized_RefreshesCacheAfterCacheDurationExpires() throws InterruptedException {
+
         byte[] initialHash = {0x01, 0x02, 0x03, 0x04};
         byte[] updatedHash = {0x01, 0x02, 0x03, 0x05};
 
-        var client = new FakeClient(new FeatureToggles(
+        var client = new MockOctopusFeatureClient(new FeatureToggles(
             List.of(new FeatureToggleEvaluation("test-feature", true, "evaluation-key", Collections.emptyList(), 100)),
             initialHash
         ));
-        var provider = new OctopusContextProvider(fastConfig(), client);
+
+        var provider = new OctopusContextProvider(configuration, client);
         provider.initialize();
 
         try {
+            // Validate the initial state
             assertThat(provider.getOctopusContext().getContentHash()).isEqualTo(initialHash);
             assertThat(provider.getOctopusContext().evaluate("test-feature", false, null).getValue()).isTrue();
 
+            // Simulate a change in the available feature toggles
             client.changeToggles(new FeatureToggles(
                 List.of(new FeatureToggleEvaluation("test-feature", false, "evaluation-key", Collections.emptyList(), 100)),
                 updatedHash
             ));
+
+            // Wait for the cache to expire
             Thread.sleep(500);
 
+            // Validate the updated toggles are available
             assertThat(provider.getOctopusContext().getContentHash()).isEqualTo(updatedHash);
             assertThat(provider.getOctopusContext().evaluate("test-feature", false, null).getValue()).isFalse();
+
         } finally {
             provider.shutdown();
         }
@@ -74,9 +83,10 @@ class OctopusContextProviderTests {
 
     @Test
     void whenInitialized_AndRefreshFails_RetainsExistingContextAndLogsError() throws InterruptedException {
+
         byte[] contentHash = {0x01, 0x02, 0x03, 0x04};
 
-        var client = new FakeClient(new FeatureToggles(
+        var client = new MockOctopusFeatureClient(new FeatureToggles(
             List.of(new FeatureToggleEvaluation("test-feature", true, "evaluation-key", Collections.emptyList(), 100)),
             contentHash
         ));
@@ -90,16 +100,22 @@ class OctopusContextProviderTests {
         };
         julLogger.addHandler(handler);
 
-        var provider = new OctopusContextProvider(fastConfig(), client);
+        var provider = new OctopusContextProvider(configuration, client);
+
         try {
             provider.initialize();
 
+            // Simulate a failed fetch
             client.changeToggles(null);
+
+            // Wait for the cache to expire
             Thread.sleep(500);
 
+            // Validate that the existing context is retained and an error was logged
             assertThat(provider.getOctopusContext().getContentHash()).isEqualTo(contentHash);
             assertThat(provider.getOctopusContext().evaluate("test-feature", false, null).getValue()).isTrue();
             assertThat(logMessages).anyMatch(m -> m.startsWith("Failed to retrieve updated feature manifest"));
+
         } finally {
             julLogger.removeHandler(handler);
             provider.shutdown();

--- a/src/test/java/com/octopus/openfeature/provider/OctopusContextProviderTests.java
+++ b/src/test/java/com/octopus/openfeature/provider/OctopusContextProviderTests.java
@@ -74,7 +74,7 @@ class OctopusContextProviderTests {
 
             // Validate the updated toggles are available
             assertThat(provider.getOctopusContext().getContentHash()).isEqualTo(updatedHash);
-            assertThat(provider.getOctopusContext().evaluate("test-feature", false, null).getValue()).isFalse();
+            assertThat(provider.getOctopusContext().evaluate("test-feature", true, null).getValue()).isFalse();
 
         } finally {
             provider.shutdown();

--- a/src/test/java/com/octopus/openfeature/provider/OctopusContextProviderTests.java
+++ b/src/test/java/com/octopus/openfeature/provider/OctopusContextProviderTests.java
@@ -1,0 +1,108 @@
+package com.octopus.openfeature.provider;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.logging.Handler;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class OctopusContextProviderTests {
+
+    static class FakeClient extends OctopusClient {
+        private volatile FeatureToggles toggles;
+
+        FakeClient(FeatureToggles toggles) {
+            super(null);
+            this.toggles = toggles;
+        }
+
+        void changeToggles(FeatureToggles toggles) {
+            this.toggles = toggles;
+        }
+
+        @Override
+        Boolean haveFeatureTogglesChanged(byte[] contentHash) {
+            return true;
+        }
+
+        @Override
+        FeatureToggles getFeatureToggleEvaluationManifest() {
+            return toggles;
+        }
+    }
+
+    private OctopusConfiguration fastConfig() {
+        var config = new OctopusConfiguration("token");
+        config.setCacheDuration(Duration.ofMillis(100));
+        return config;
+    }
+
+    @Test
+    void whenInitialized_RefreshesCacheAfterCacheDurationExpires() throws InterruptedException {
+        byte[] initialHash = {0x01, 0x02, 0x03, 0x04};
+        byte[] updatedHash = {0x01, 0x02, 0x03, 0x05};
+
+        var client = new FakeClient(new FeatureToggles(
+            List.of(new FeatureToggleEvaluation("test-feature", true, "evaluation-key", Collections.emptyList(), 100)),
+            initialHash
+        ));
+        var provider = new OctopusContextProvider(fastConfig(), client);
+        provider.initialize();
+
+        try {
+            assertThat(provider.getOctopusContext().getContentHash()).isEqualTo(initialHash);
+            assertThat(provider.getOctopusContext().evaluate("test-feature", false, null).getValue()).isTrue();
+
+            client.changeToggles(new FeatureToggles(
+                List.of(new FeatureToggleEvaluation("test-feature", false, "evaluation-key", Collections.emptyList(), 100)),
+                updatedHash
+            ));
+            Thread.sleep(500);
+
+            assertThat(provider.getOctopusContext().getContentHash()).isEqualTo(updatedHash);
+            assertThat(provider.getOctopusContext().evaluate("test-feature", false, null).getValue()).isFalse();
+        } finally {
+            provider.shutdown();
+        }
+    }
+
+    @Test
+    void whenInitialized_AndRefreshFails_RetainsExistingContextAndLogsError() throws InterruptedException {
+        byte[] contentHash = {0x01, 0x02, 0x03, 0x04};
+
+        var client = new FakeClient(new FeatureToggles(
+            List.of(new FeatureToggleEvaluation("test-feature", true, "evaluation-key", Collections.emptyList(), 100)),
+            contentHash
+        ));
+
+        var logMessages = new ArrayList<String>();
+        var julLogger = Logger.getLogger(OctopusClient.class.getName());
+        var handler = new Handler() {
+            @Override public void publish(LogRecord record) { logMessages.add(record.getMessage()); }
+            @Override public void flush() {}
+            @Override public void close() {}
+        };
+        julLogger.addHandler(handler);
+
+        var provider = new OctopusContextProvider(fastConfig(), client);
+        try {
+            provider.initialize();
+
+            client.changeToggles(null);
+            Thread.sleep(500);
+
+            assertThat(provider.getOctopusContext().getContentHash()).isEqualTo(contentHash);
+            assertThat(provider.getOctopusContext().evaluate("test-feature", false, null).getValue()).isTrue();
+            assertThat(logMessages).anyMatch(m -> m.startsWith("Failed to retrieve updated feature manifest"));
+        } finally {
+            julLogger.removeHandler(handler);
+            provider.shutdown();
+        }
+    }
+}


### PR DESCRIPTION
## Background 🌇 

To ensure feature toggles are not stale, we regularly refresh the evaluation context. Currently if the refresh request fails and toggles cannot be evaluated, we fall back to using each toggle's default value.

## What's this? 🐦 

This PR adjusts the function to refresh evaluation context so that if a request to get the evaluation context fails, we fall back to using the evaluation from the existing (stale) evaluation context. 

While not perfect, we expect that the most recent evaluation will give us a more correct result than using default values. 

## Testing 🧪 

This has been tested by running the automated tests added in [`OctopusContextProviderTests.cs`](https://github.com/OctopusDeploy/openfeature-provider-java/pull/14/changes#diff-9d62d7fa505dac2a3104a334b4ab59f34369ee8a788d01f9d83de28b337d84c5R13)

🚩 These tests are a Claude special. I've checked over them carefully and done my best to make sure they are equivalent to (or better than) the same tests in our .NET library, but they could use a careful review. 

## How to review? 🔍 
💬 See comments on code
🧪 Any suggested further testing?
🚩 Carefully check my Java

Part of DEVEX-41