### PR TITLE
chore: Fix test compilation broken by merge

### DIFF
--- a/src/test/java/com/octopus/openfeature/provider/OctopusContextProviderTests.java
+++ b/src/test/java/com/octopus/openfeature/provider/OctopusContextProviderTests.java
@@ -39,7 +39,7 @@ class OctopusContextProviderTests {
     private final OctopusConfiguration configuration = configure();
 
     private static OctopusConfiguration configure() {
-        var config = new OctopusConfiguration("token");
+        var config = new OctopusConfiguration("token", new ProductMetadata("TestClient"));
         config.setCacheDuration(Duration.ofMillis(100));
         return config;
     }


### PR DESCRIPTION
# Background

https://github.com/OctopusDeploy/openfeature-provider-java/pull/14 added new tests that constructed an `OctopusConfiguration` object.

https://github.com/OctopusDeploy/openfeature-provider-java/pull/13 added a breaking change to the constructor for `OctopusConfiguration`.