### PR TITLE
fix: Simplify refresh logic on a failed fetch

### DIFF
--- a/src/main/java/com/octopus/openfeature/provider/OctopusClient.java
+++ b/src/main/java/com/octopus/openfeature/provider/OctopusClient.java
@@ -43,7 +43,7 @@ class OctopusClient {
         this.config = config;
     }
 
-    Boolean haveFeatureTogglesChanged(byte[] contentHash) {
+    Boolean haveFeatureTogglesChanged(byte[] contentHash) throws IOException, InterruptedException {
         if (contentHash.length == 0) {
             return true;
         }
@@ -55,18 +55,12 @@ class OctopusClient {
                 .header("Authorization", String.format("Bearer %s", config.getClientIdentifier()))
                 .header("X-Octopus-Client", buildOctopusClientHeaderValue())
                 .build();
-        try {
-            HttpResponse<String> httpResponse = client.send(request, HttpResponse.BodyHandlers.ofString());
-            FeatureToggleCheckResponse checkResponse = OctopusObjectMapper.INSTANCE.readValue(httpResponse.body(), FeatureToggleCheckResponse.class);
-            return !Arrays.equals(checkResponse.contentHash, contentHash);
-        } catch (Exception e) {
-            logger.log(System.Logger.Level.WARNING, String.format("Unable to query Octopus Feature Toggle service. URI: %s", checkURI.toString()), e);
-            // Use cached toggles
-            return false;
-        }
+        HttpResponse<String> httpResponse = client.send(request, HttpResponse.BodyHandlers.ofString());
+        FeatureToggleCheckResponse checkResponse = OctopusObjectMapper.INSTANCE.readValue(httpResponse.body(), FeatureToggleCheckResponse.class);
+        return !Arrays.equals(checkResponse.contentHash, contentHash);
     }
 
-    FeatureToggles getFeatureToggleEvaluationManifest() {
+    FeatureToggles getFeatureToggleEvaluationManifest() throws IOException, InterruptedException {
         URI manifestURI = getManifestURI();
         HttpClient client = HttpClient.newHttpClient();
         HttpRequest request = HttpRequest.newBuilder()
@@ -75,23 +69,18 @@ class OctopusClient {
                 .header("Authorization", String.format("Bearer %s", config.getClientIdentifier()))
                 .header("X-Octopus-Client", buildOctopusClientHeaderValue())
                 .build();
-        try {
-            HttpResponse<String> httpResponse = client.send(request, HttpResponse.BodyHandlers.ofString());
-            if (httpResponse.statusCode() == StatusCodeNotFound) {
-                logger.log(System.Logger.Level.WARNING, String.format("Failed to retrieve feature toggles for client identifier %s from %s", config.getClientIdentifier(), manifestURI.toString()));
-                return null;
-            }
-            Optional<String> contentHashHeader = httpResponse.headers().firstValue("ContentHash");
-            if (contentHashHeader.isEmpty()) {
-                logger.log(System.Logger.Level.WARNING, String.format("Feature toggle response from %s did not contain expected ContentHash header", manifestURI.toString()));
-                return null;
-            }
-            var evaluations = OctopusObjectMapper.INSTANCE.readValue(httpResponse.body(), new TypeReference<List<FeatureToggleEvaluation>>() {});
-            return new FeatureToggles(evaluations, Base64.getDecoder().decode(contentHashHeader.get()));
-        } catch (Exception e) {
-            logger.log(System.Logger.Level.WARNING, "Unable to query Octopus Feature Toggle service", e);
+        HttpResponse<String> httpResponse = client.send(request, HttpResponse.BodyHandlers.ofString());
+        if (httpResponse.statusCode() == StatusCodeNotFound) {
+            logger.log(System.Logger.Level.WARNING, String.format("Failed to retrieve feature toggles for client identifier %s from %s", config.getClientIdentifier(), manifestURI.toString()));
             return null;
         }
+        Optional<String> contentHashHeader = httpResponse.headers().firstValue("ContentHash");
+        if (contentHashHeader.isEmpty()) {
+            logger.log(System.Logger.Level.WARNING, String.format("Feature toggle response from %s did not contain expected ContentHash header", manifestURI.toString()));
+            return null;
+        }
+        var evaluations = OctopusObjectMapper.INSTANCE.readValue(httpResponse.body(), new TypeReference<List<FeatureToggleEvaluation>>() {});
+        return new FeatureToggles(evaluations, Base64.getDecoder().decode(contentHashHeader.get()));
     }
 
     String buildOctopusClientHeaderValue() {

--- a/src/main/java/com/octopus/openfeature/provider/OctopusContextProvider.java
+++ b/src/main/java/com/octopus/openfeature/provider/OctopusContextProvider.java
@@ -24,7 +24,7 @@ class OctopusContextProvider {
             var toggles = client.getFeatureToggleEvaluationManifest();
             currentContext = toggles == null ? OctopusContext.empty() : new OctopusContext(toggles);
         } catch (Exception e) {
-            logger.log(System.Logger.Level.ERROR, "Failed to retrieve feature toggles during initialization. Falling back to empty context. Default values will be used during evaluated.", e);
+            logger.log(System.Logger.Level.ERROR, "Failed to retrieve feature manifest during initialization. Falling back to empty context, defaults will be used during evaluation.", e);
             currentContext = OctopusContext.empty();
         }
 

--- a/src/main/java/com/octopus/openfeature/provider/OctopusContextProvider.java
+++ b/src/main/java/com/octopus/openfeature/provider/OctopusContextProvider.java
@@ -1,7 +1,5 @@
 package com.octopus.openfeature.provider;
 
-import java.time.Duration;
-
 class OctopusContextProvider {
     private final OctopusConfiguration config;
     private final OctopusClient client;
@@ -9,7 +7,6 @@ class OctopusContextProvider {
     private OctopusContext currentContext = OctopusContext.empty();
     private Thread refreshThread;
     private static final System.Logger logger = System.getLogger(OctopusClient.class.getName());
-    private static final Duration retryDelay = Duration.ofSeconds(5);
 
     OctopusContextProvider(OctopusConfiguration config, OctopusClient client) {
         this.config = config;
@@ -44,11 +41,9 @@ class OctopusContextProvider {
      otherwise the state will be left stale whilst the consumer continues to make use it.
      */
     void refresh() {
-        int retryAttempt = 0;
-        var delay = config.getCacheDuration();
         while (!Thread.currentThread().isInterrupted()) {
             try {
-                Thread.sleep(delay.toMillis());
+                Thread.sleep(config.getCacheDuration().toMillis());
 
                 if (client.haveFeatureTogglesChanged(currentContext.getContentHash())) {
                     var toggles = client.getFeatureToggleEvaluationManifest();
@@ -58,17 +53,11 @@ class OctopusContextProvider {
                         logger.log(System.Logger.Level.ERROR, "Failed to retrieve updated feature manifest. Retaining existing context which may be stale.");
                     }
                 }
-
-                delay = config.getCacheDuration();
-                retryAttempt = 0;
-
             } catch (InterruptedException e) {
                 // the loop will be terminated and the thread will finish
                 Thread.currentThread().interrupt();
             } catch (Exception e) {
-                logger.log(System.Logger.Level.ERROR, String.format("Failed to refresh feature toggles. Retry attempt %d", retryAttempt), e);
-                delay = retryDelay;
-                retryAttempt++;
+                logger.log(System.Logger.Level.ERROR, "Failed to retrieve updated feature manifest. Retaining existing context which may be stale.", e);
             }
         }
     }

--- a/src/test/java/com/octopus/openfeature/provider/OctopusContextProviderTests.java
+++ b/src/test/java/com/octopus/openfeature/provider/OctopusContextProviderTests.java
@@ -121,4 +121,139 @@ class OctopusContextProviderTests {
             provider.shutdown();
         }
     }
+
+    @Test
+    void whenInitialFetchReturnsNothing_AndRefreshSucceeds_ContextIsPopulated() throws InterruptedException {
+
+        byte[] contentHash = {0x01, 0x02, 0x03, 0x04};
+
+        // Initialize with null so first fetch fails
+        var client = new MockOctopusFeatureClient(null);
+        var provider = new OctopusContextProvider(configuration, client);
+        provider.initialize();
+
+        try {
+            // Check that the context is empty
+            assertThat(provider.getOctopusContext().getContentHash()).isEmpty();
+
+            // Update client to return valid toggles and wait for refresh
+            client.changeToggles(new FeatureToggles(
+                List.of(new FeatureToggleEvaluation("test-feature", false, "evaluation-key", Collections.emptyList(), 100)),
+                contentHash
+            ));
+            Thread.sleep(5000);
+
+            // Assert that the context is now correctly populated
+            assertThat(provider.getOctopusContext().getContentHash()).isEqualTo(contentHash);
+
+        } finally {
+            provider.shutdown();
+        }
+    }
+
+    @Test
+    void whenRefreshReturnsNothing_AndSubsequentRefreshSucceeds_ContextIsUpdated() throws InterruptedException {
+
+        byte[] initialHash = {0x01, 0x02, 0x03, 0x04};
+        byte[] updatedHash = {0x01, 0x02, 0x03, 0x05};
+
+        var logMessages = new ArrayList<String>();
+        var julLogger = Logger.getLogger(OctopusClient.class.getName());
+        var handler = new Handler() {
+            @Override public void publish(LogRecord record) { logMessages.add(record.getMessage()); }
+            @Override public void flush() {}
+            @Override public void close() {}
+        };
+        julLogger.addHandler(handler);
+
+        // initialize with a client that returns valid toggles
+        var client = new MockOctopusFeatureClient(new FeatureToggles(
+            List.of(new FeatureToggleEvaluation("test-feature", true, "evaluation-key", Collections.emptyList(), 100)),
+            initialHash
+        ));
+        var provider = new OctopusContextProvider(configuration, client);
+        provider.initialize();
+
+        try {
+            // Switch to a null client and wait for refresh to fail
+            client.changeToggles(null);
+            Thread.sleep(5000);
+
+            // Assert that failed refresh is logged and old context is retained
+            assertThat(logMessages).anyMatch(m -> m.startsWith("Failed to retrieve updated feature manifest"));
+            assertThat(provider.getOctopusContext().getContentHash()).isEqualTo(initialHash);
+
+            // Update client to return valid toggles again and wait for refresh
+            client.changeToggles(new FeatureToggles(
+                List.of(new FeatureToggleEvaluation("test-feature", false, "evaluation-key", Collections.emptyList(), 100)),
+                updatedHash
+            ));
+            Thread.sleep(5000);
+
+            assertThat(provider.getOctopusContext().getContentHash()).isEqualTo(updatedHash);
+
+        } finally {
+            julLogger.removeHandler(handler);
+            provider.shutdown();
+        }
+    }
+
+    static class ThrowsOnRefreshClient extends OctopusClient {
+
+        static final String ERROR_MESSAGE = "Oops! Simulated refresh error";
+        private final FeatureToggles initial;
+
+        ThrowsOnRefreshClient(FeatureToggles initial) {
+            super(null);
+            this.initial = initial;
+        }
+
+        @Override
+        Boolean haveFeatureTogglesChanged(byte[] contentHash) {
+            throw new RuntimeException(ERROR_MESSAGE);
+        }
+
+        @Override
+        FeatureToggles getFeatureToggleEvaluationManifest() {
+            return initial;
+        }
+    }
+
+    @Test
+    void whenAnExceptionIsThrownDuringRefresh_LogsErrorDetails() throws InterruptedException {
+
+        byte[] contentHash = {0x01, 0x02, 0x03, 0x04};
+
+        var logRecords = new ArrayList<LogRecord>();
+        var julLogger = Logger.getLogger(OctopusClient.class.getName());
+        var handler = new Handler() {
+            @Override public void publish(LogRecord record) { logRecords.add(record); }
+            @Override public void flush() {}
+            @Override public void close() {}
+        };
+        julLogger.addHandler(handler);
+
+        // Initialize with a client that will throw on refresh
+        var client = new ThrowsOnRefreshClient(new FeatureToggles(
+            List.of(new FeatureToggleEvaluation("test-feature", true, "evaluation-key", Collections.emptyList(), 100)),
+            contentHash
+        ));
+        var provider = new OctopusContextProvider(configuration, client);
+        provider.initialize();
+
+        try {
+            // Wait for cache to expire and refresh attempt to throw
+            Thread.sleep(500);
+
+            assertThat(logRecords).anyMatch(r ->
+                r.getMessage().startsWith("Failed to retrieve updated feature manifest")
+                && r.getThrown() != null
+                && r.getThrown().getMessage().contains(ThrowsOnRefreshClient.ERROR_MESSAGE)
+            );
+
+        } finally {
+            julLogger.removeHandler(handler);
+            provider.shutdown();
+        }
+    }
 }

--- a/src/test/java/com/octopus/openfeature/provider/OctopusContextProviderTests.java
+++ b/src/test/java/com/octopus/openfeature/provider/OctopusContextProviderTests.java
@@ -105,6 +105,9 @@ class OctopusContextProviderTests {
         try {
             provider.initialize();
 
+            // Stop warnings about refresh failures from reaching the test output
+            julLogger.setUseParentHandlers(false);
+
             // Simulate a failed fetch
             client.changeToggles(null);
 
@@ -118,6 +121,7 @@ class OctopusContextProviderTests {
 
         } finally {
             julLogger.removeHandler(handler);
+            julLogger.setUseParentHandlers(true);
             provider.shutdown();
         }
     }
@@ -126,6 +130,9 @@ class OctopusContextProviderTests {
     void whenInitialFetchReturnsNothing_AndRefreshSucceeds_ContextIsPopulated() throws InterruptedException {
 
         byte[] contentHash = {0x01, 0x02, 0x03, 0x04};
+
+        var julLogger = Logger.getLogger(OctopusClient.class.getName());
+        julLogger.setUseParentHandlers(false);
 
         // Initialize with null so first fetch fails
         var client = new MockOctopusFeatureClient(null);
@@ -147,6 +154,7 @@ class OctopusContextProviderTests {
             assertThat(provider.getOctopusContext().getContentHash()).isEqualTo(contentHash);
 
         } finally {
+            julLogger.setUseParentHandlers(true);
             provider.shutdown();
         }
     }
@@ -174,6 +182,9 @@ class OctopusContextProviderTests {
         var provider = new OctopusContextProvider(configuration, client);
         provider.initialize();
 
+        // Stop warnings about refresh failures from reaching the test output
+        julLogger.setUseParentHandlers(false);
+
         try {
             // Switch to a null client and wait for refresh to fail
             client.changeToggles(null);
@@ -194,6 +205,7 @@ class OctopusContextProviderTests {
 
         } finally {
             julLogger.removeHandler(handler);
+            julLogger.setUseParentHandlers(true);
             provider.shutdown();
         }
     }
@@ -232,6 +244,8 @@ class OctopusContextProviderTests {
             @Override public void close() {}
         };
         julLogger.addHandler(handler);
+        // Stop warnings about refresh failures from reaching the test output
+        julLogger.setUseParentHandlers(false);
 
         // Initialize with a client that will throw on refresh
         var client = new ThrowsOnRefreshClient(new FeatureToggles(
@@ -253,6 +267,7 @@ class OctopusContextProviderTests {
 
         } finally {
             julLogger.removeHandler(handler);
+            julLogger.setUseParentHandlers(true);
             provider.shutdown();
         }
     }

--- a/src/test/java/com/octopus/openfeature/provider/OctopusContextProviderTests.java
+++ b/src/test/java/com/octopus/openfeature/provider/OctopusContextProviderTests.java
@@ -3,6 +3,7 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.logging.Handler;
 import java.util.logging.LogRecord;
 import java.util.logging.Logger;
@@ -165,7 +166,7 @@ class OctopusContextProviderTests {
         byte[] initialHash = {0x01, 0x02, 0x03, 0x04};
         byte[] updatedHash = {0x01, 0x02, 0x03, 0x05};
 
-        var logMessages = new ArrayList<String>();
+        var logMessages = new CopyOnWriteArrayList<String>();
         var julLogger = Logger.getLogger(OctopusClient.class.getName());
         var handler = new Handler() {
             @Override public void publish(LogRecord record) { logMessages.add(record.getMessage()); }
@@ -236,7 +237,7 @@ class OctopusContextProviderTests {
 
         byte[] contentHash = {0x01, 0x02, 0x03, 0x04};
 
-        var logRecords = new ArrayList<LogRecord>();
+        var logRecords = new CopyOnWriteArrayList<LogRecord>();
         var julLogger = Logger.getLogger(OctopusClient.class.getName());
         var handler = new Handler() {
             @Override public void publish(LogRecord record) { logRecords.add(record); }


### PR DESCRIPTION
## Background 🌇

The feature toggle evaluation manifest is fetched when a provider is initialized and then refreshed regularly according to a cache interval. If one of these fetches fails, the refresh interval drops from the cache duration (default one min) down to five seconds. This could significantly increase load on OctoToggle in the event of an outage and does not seem worth the cost considering that we already have regular refreshes at the cache duration interval.  

In [DEVEX-41](https://linear.app/octopus/issue/DEVEX-41/failed-requests-should-not-reset-the-toggle-states), we added logic to fall back the most recent set of evaluations in the case where a refresh fails, rather than falling back to default toggle states. This made waiting the cache duration for a refresh (rather than frantically retrying) a more acceptable option. 

## What's this? 🐦

The PR removes the fast-refresh logic. Now instead of dropping down to a five second refresh interval on failure, we just carry on refreshing at the caching interval.  

## Testing 🧪
✅ I've given these changes a manual test with both the Functions and ASP.NET OctoToggle setup
✅ The updated **refresh** logic has has been tested using the tests added in this PR. 

## How to review? 🔍
💬 Check out the comments on the code
☑️ Code quality

Completes DEVEX-84