### PR TITLE
fix!: Return correct errors for unsupported flag types

### DIFF
--- a/src/main/java/com/octopus/openfeature/provider/OctopusContext.java
+++ b/src/main/java/com/octopus/openfeature/provider/OctopusContext.java
@@ -27,10 +27,14 @@ class OctopusContext {
         return featureToggles.getContentHash();
     }
 
-    ProviderEvaluation<Boolean> evaluate(String slug, Boolean defaultValue, EvaluationContext evaluationContext) {
-        var toggleValue = featureToggles.getEvaluations().stream()
+    FeatureToggleEvaluation findFeatureToggleBySlug(String slug) {
+        return featureToggles.getEvaluations().stream()
                 .filter(f -> f.getSlug().equalsIgnoreCase(slug))
                 .findFirst().orElse(null);
+    }
+
+    ProviderEvaluation<Boolean> evaluate(String slug, Boolean defaultValue, EvaluationContext evaluationContext) {
+        var toggleValue = findFeatureToggleBySlug(slug);
 
         if (toggleValue == null) {
             throw new FlagNotFoundError();

--- a/src/main/java/com/octopus/openfeature/provider/OctopusContextProvider.java
+++ b/src/main/java/com/octopus/openfeature/provider/OctopusContextProvider.java
@@ -12,14 +12,6 @@ class OctopusContextProvider {
         this.config = config;
         this.client = client;
     }
-
-    // For unit testing: skips HTTP fetch and background refresh by pre-loading a known context.
-    OctopusContextProvider(OctopusContext context) {
-        this.config = null;
-        this.client = null;
-        this.currentContext = context;
-        this.initialized = true;
-    }
     
     OctopusContext getOctopusContext() { return currentContext; }
 

--- a/src/main/java/com/octopus/openfeature/provider/OctopusContextProvider.java
+++ b/src/main/java/com/octopus/openfeature/provider/OctopusContextProvider.java
@@ -12,6 +12,14 @@ class OctopusContextProvider {
         this.config = config;
         this.client = client;
     }
+
+    // For unit testing: skips HTTP fetch and background refresh by pre-loading a known context.
+    OctopusContextProvider(OctopusContext context) {
+        this.config = null;
+        this.client = null;
+        this.currentContext = context;
+        this.initialized = true;
+    }
     
     OctopusContext getOctopusContext() { return currentContext; }
 

--- a/src/main/java/com/octopus/openfeature/provider/OctopusProvider.java
+++ b/src/main/java/com/octopus/openfeature/provider/OctopusProvider.java
@@ -1,6 +1,12 @@
 package com.octopus.openfeature.provider;
 
-import dev.openfeature.sdk.*;
+import dev.openfeature.sdk.EvaluationContext;
+import dev.openfeature.sdk.EventProvider;
+import dev.openfeature.sdk.Metadata;
+import dev.openfeature.sdk.ProviderEvaluation;
+import dev.openfeature.sdk.Value;
+import dev.openfeature.sdk.exceptions.FlagNotFoundError;
+import dev.openfeature.sdk.exceptions.TypeMismatchError;
 
 public class OctopusProvider extends EventProvider {
     private static final String PROVIDER_NAME = "octopus-java-provider";
@@ -8,10 +14,10 @@ public class OctopusProvider extends EventProvider {
     private final OctopusContextProvider contextProvider;
     
     public OctopusProvider(OctopusConfiguration config) {
-       this.config = config; 
+       this.config = config;
        this.contextProvider = new OctopusContextProvider(config, new OctopusClient(config));
     }
-    
+
     @Override
     public Metadata getMetadata() { return () -> PROVIDER_NAME; }
 
@@ -33,22 +39,30 @@ public class OctopusProvider extends EventProvider {
     }
 
     @Override
-    public ProviderEvaluation<String> getStringEvaluation(String s, String s1, EvaluationContext evaluationContext) {
-        throw new UnsupportedOperationException("Only boolean values are currently supported");
+    public ProviderEvaluation<String> getStringEvaluation(String flagKey, String defaultValue, EvaluationContext evaluationContext) {
+        throw rejectNonBooleanEvaluation(flagKey);
     }
 
     @Override
-    public ProviderEvaluation<Integer> getIntegerEvaluation(String s, Integer integer, EvaluationContext evaluationContext) {
-        throw new UnsupportedOperationException("Only boolean values are currently supported");
+    public ProviderEvaluation<Integer> getIntegerEvaluation(String flagKey, Integer defaultValue, EvaluationContext evaluationContext) {
+        throw rejectNonBooleanEvaluation(flagKey);
     }
 
     @Override
-    public ProviderEvaluation<Double> getDoubleEvaluation(String s, Double aDouble, EvaluationContext evaluationContext) {
-        throw new UnsupportedOperationException("Only boolean values are currently supported");
+    public ProviderEvaluation<Double> getDoubleEvaluation(String flagKey, Double defaultValue, EvaluationContext evaluationContext) {
+        throw rejectNonBooleanEvaluation(flagKey);
     }
 
     @Override
-    public ProviderEvaluation<Value> getObjectEvaluation(String s, Value value, EvaluationContext evaluationContext) {
-        throw new UnsupportedOperationException("Only boolean values are currently supported");
+    public ProviderEvaluation<Value> getObjectEvaluation(String flagKey, Value defaultValue, EvaluationContext evaluationContext) {
+        throw rejectNonBooleanEvaluation(flagKey);
+    }
+
+    private RuntimeException rejectNonBooleanEvaluation(String flagKey) {
+        var toggle = contextProvider.getOctopusContext().findFeatureToggleBySlug(flagKey);
+        if (toggle == null) {
+            return new FlagNotFoundError(flagKey);
+        }
+        return new TypeMismatchError("Octopus Feature Toggles only supports boolean toggles.");
     }
 }

--- a/src/main/java/com/octopus/openfeature/provider/OctopusProvider.java
+++ b/src/main/java/com/octopus/openfeature/provider/OctopusProvider.java
@@ -14,7 +14,7 @@ public class OctopusProvider extends EventProvider {
     private final OctopusContextProvider contextProvider;
     
     public OctopusProvider(OctopusConfiguration config) {
-       this.config = config;
+       this.config = config; 
        this.contextProvider = new OctopusContextProvider(config, new OctopusClient(config));
     }
 
@@ -69,6 +69,6 @@ public class OctopusProvider extends EventProvider {
         if (toggle == null) {
             return new FlagNotFoundError(flagKey);
         }
-        return new TypeMismatchError("Octopus Feature Toggles only supports boolean toggles.");
+        return new TypeMismatchError("Octopus only supports boolean flags.");
     }
 }

--- a/src/main/java/com/octopus/openfeature/provider/OctopusProvider.java
+++ b/src/main/java/com/octopus/openfeature/provider/OctopusProvider.java
@@ -1,10 +1,6 @@
 package com.octopus.openfeature.provider;
 
-import dev.openfeature.sdk.EvaluationContext;
-import dev.openfeature.sdk.EventProvider;
-import dev.openfeature.sdk.Metadata;
-import dev.openfeature.sdk.ProviderEvaluation;
-import dev.openfeature.sdk.Value;
+import dev.openfeature.sdk.*;
 import dev.openfeature.sdk.exceptions.FlagNotFoundError;
 import dev.openfeature.sdk.exceptions.TypeMismatchError;
 
@@ -18,7 +14,7 @@ public class OctopusProvider extends EventProvider {
        this.contextProvider = new OctopusContextProvider(config, new OctopusClient(config));
     }
 
-    // For unit testing: accepts a pre-built context provider instead of constructing one from config.
+    // For testing: accepts a pre-built context provider instead of constructing one from config.
     OctopusProvider(OctopusContextProvider contextProvider) {
         this.config = null;
         this.contextProvider = contextProvider;

--- a/src/main/java/com/octopus/openfeature/provider/OctopusProvider.java
+++ b/src/main/java/com/octopus/openfeature/provider/OctopusProvider.java
@@ -18,6 +18,12 @@ public class OctopusProvider extends EventProvider {
        this.contextProvider = new OctopusContextProvider(config, new OctopusClient(config));
     }
 
+    // For unit testing: accepts a pre-built context provider instead of constructing one from config.
+    OctopusProvider(OctopusContextProvider contextProvider) {
+        this.config = null;
+        this.contextProvider = contextProvider;
+    }
+
     @Override
     public Metadata getMetadata() { return () -> PROVIDER_NAME; }
 

--- a/src/test/java/com/octopus/openfeature/provider/FakeOctopusContextProvider.java
+++ b/src/test/java/com/octopus/openfeature/provider/FakeOctopusContextProvider.java
@@ -1,0 +1,20 @@
+package com.octopus.openfeature.provider;
+
+// For testing: pre-loads a known context, skipping HTTP fetch and background refresh.
+class FakeOctopusContextProvider extends OctopusContextProvider {
+    private final OctopusContext context;
+
+    FakeOctopusContextProvider(OctopusContext context) {
+        super(null, null);
+        this.context = context;
+    }
+
+    @Override
+    OctopusContext getOctopusContext() { return context; }
+
+    @Override
+    void initialize() { }
+
+    @Override
+    void shutdown() { }
+}

--- a/src/test/java/com/octopus/openfeature/provider/OctopusProviderTests.java
+++ b/src/test/java/com/octopus/openfeature/provider/OctopusProviderTests.java
@@ -23,7 +23,7 @@ class OctopusProviderTests {
                 List.of(new FeatureToggleEvaluation("feature-a", true, "key", Collections.emptyList(), 100)),
                 new byte[0]
         );
-        var provider = new OctopusProvider(new OctopusContextProvider(new OctopusContext(toggles)));
+        var provider = new OctopusProvider(new FakeOctopusContextProvider(new OctopusContext(toggles)));
         OpenFeatureAPI.getInstance().setProviderAndWait(provider);
         client = OpenFeatureAPI.getInstance().getClient();
     }

--- a/src/test/java/com/octopus/openfeature/provider/OctopusProviderTests.java
+++ b/src/test/java/com/octopus/openfeature/provider/OctopusProviderTests.java
@@ -1,0 +1,83 @@
+package com.octopus.openfeature.provider;
+
+import dev.openfeature.sdk.Client;
+import dev.openfeature.sdk.ErrorCode;
+import dev.openfeature.sdk.OpenFeatureAPI;
+import dev.openfeature.sdk.Value;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class OctopusProviderTests {
+
+    private Client client;
+
+    @BeforeEach
+    void setup() throws Exception {
+        var toggles = new FeatureToggles(
+                List.of(new FeatureToggleEvaluation("feature-a", true, "key", Collections.emptyList(), 100)),
+                new byte[0]
+        );
+        var provider = new OctopusProvider(new OctopusContextProvider(new OctopusContext(toggles)));
+        OpenFeatureAPI.getInstance().setProviderAndWait(provider);
+        client = OpenFeatureAPI.getInstance().getClient();
+    }
+
+    @AfterEach
+    void teardown() {
+        OpenFeatureAPI.getInstance().shutdown();
+    }
+
+    @Test
+    void givenAKnownFlag_whenRequestedAsString_returnsTypeMismatch() {
+        assertThat(client.getStringDetails("feature-a", "default").getErrorCode())
+                .isEqualTo(ErrorCode.TYPE_MISMATCH);
+    }
+
+    @Test
+    void givenAnUnknownFlag_whenRequestedAsString_returnsFlagNotFound() {
+        assertThat(client.getStringDetails("nonexistent", "default").getErrorCode())
+                .isEqualTo(ErrorCode.FLAG_NOT_FOUND);
+    }
+
+    @Test
+    void givenAKnownFlag_whenRequestedAsInteger_returnsTypeMismatch() {
+        assertThat(client.getIntegerDetails("feature-a", 0).getErrorCode())
+                .isEqualTo(ErrorCode.TYPE_MISMATCH);
+    }
+
+    @Test
+    void givenAnUnknownFlag_whenRequestedAsInteger_returnsFlagNotFound() {
+        assertThat(client.getIntegerDetails("nonexistent", 0).getErrorCode())
+                .isEqualTo(ErrorCode.FLAG_NOT_FOUND);
+    }
+
+    @Test
+    void givenAKnownFlag_whenRequestedAsDouble_returnsTypeMismatch() {
+        assertThat(client.getDoubleDetails("feature-a", 0.0).getErrorCode())
+                .isEqualTo(ErrorCode.TYPE_MISMATCH);
+    }
+
+    @Test
+    void givenAnUnknownFlag_whenRequestedAsDouble_returnsFlagNotFound() {
+        assertThat(client.getDoubleDetails("nonexistent", 0.0).getErrorCode())
+                .isEqualTo(ErrorCode.FLAG_NOT_FOUND);
+    }
+
+    @Test
+    void givenAKnownFlag_whenRequestedAsObject_returnsTypeMismatch() {
+        assertThat(client.getObjectDetails("feature-a", new Value()).getErrorCode())
+                .isEqualTo(ErrorCode.TYPE_MISMATCH);
+    }
+
+    @Test
+    void givenAnUnknownFlag_whenRequestedAsObject_returnsFlagNotFound() {
+        assertThat(client.getObjectDetails("nonexistent", new Value()).getErrorCode())
+                .isEqualTo(ErrorCode.FLAG_NOT_FOUND);
+    }
+}


### PR DESCRIPTION
## Background 🌇 

At present, OctoToggle only supports boolean type feature flags, however the OpenFeature SDK also allows string, integer, number and object type feature flags. Currently when we attempt to solve for a non-boolean value, we throw a NotImplementedException, however [OpenFeature provides us with error types](https://openfeature.dev/specification/types/#error-code) which would give a more informative response. 

## What this? 🐦 

This PR adjusts each of our functions which resolve a non-boolean feature flag to return:
- FLAG_NOT_FOUND - in cases where the the slug cannot be matched with any existing toggles,
- TYPE_MISMATCH - in cases where a correct slug is provided.

As part of this, I've converted the slug existence check in `OctopusContext` into a shared function which can be used by `OctopusProvider`.

## Testing 🧪 

✅ Tested manually for both the Function App and ASP.NET implementations - both error types are throwing correctly and valid slugs can still be evaluated for.
✅ Unit tested with the tests included with this PR.

Considering that these error messages are not core functionality, unit tests are fine for now. We also considered [adding specifications tests](https://github.com/OctopusDeploy/openfeature-provider-dotnet/pull/56). However this would have required a separate schema and test class for the non-boolean cases, potentially causing us problems later if we're adding other flag types. 

## How to review? 🔍
💬 Check the comments on the code
🚩 Be aware that this is PR is more Claude generated than the TS & .NET versions. 

Part of DEVEX-255