### PR TITLE
ci: Use last-release-sha to anchor Release Please

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,5 +1,5 @@
 {
-    "bootstrap-sha": "26972923f3af69c245fd65e98821eb9992d8d57b",
+    "last-release-sha": "26972923f3af69c245fd65e98821eb9992d8d57b",
     "packages": {
         ".": {
             "release-type": "simple",


### PR DESCRIPTION
# Background

Release Please was added to this repo in https://github.com/OctopusDeploy/openfeature-provider-java/pull/18. `bootstrap-sha` was set in `release-please-config.json`, but Release Please is picking up the `0.3.0` tag (which is on a release branch, not `main`). As such, the Release Please PR lists a number of changes that have already been released.

# Changes

Using `last-release-sha` in place of `bootstrap-sha`. After the next release, this config will be removed and we'll revert to default Release Please behaviour.

# References

https://github.com/googleapis/release-please/blob/main/docs/manifest-releaser.md#:~:text=PR%20is%20merged-,%22last%2Drelease%2Dsha%22,-%3A%20%227td2b9838885b3adf52e78ddd23ac01cb819e631%22