### PR TITLE
ci: add Renovate

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -11,6 +11,9 @@ on:
         default: false
         type: boolean
 
+permissions:
+  contents: read
+
 jobs:
   renovate:
     name: Renovate

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -1,0 +1,27 @@
+name: Renovate update dependencies
+on:
+  schedule:
+    # UTC 10:00 PM Sunday - Thursday (AEST 8:00 AM, Monday - Friday)
+    - cron: "0 22 * * 0-4"
+  workflow_dispatch:
+    inputs:
+      dry-run:
+        description: "Dry run"
+        required: false
+        default: false
+        type: boolean
+
+jobs:
+  renovate:
+    name: Renovate
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Renovate
+        uses: renovatebot/github-action@6d859fc95779be83a0335ca704879b47e5d79641 # v46.1.16
+        with:
+          configurationFile: renovate-config.js
+          token: ${{ secrets.RENOVATE_GITHUB_TOKEN }}
+        env:
+          RENOVATE_DRY_RUN: ${{ inputs.dry-run && 'full' || null }}

--- a/renovate-config.js
+++ b/renovate-config.js
@@ -14,6 +14,10 @@ module.exports = {
   // Add labels to PRs
   labels: ['dependencies'],
 
+  // Wait until a release has been published for at least 2 days before updating,
+  // to avoid picking up versions that get yanked or hotfixed shortly after release.
+  minimumReleaseAge: '2 days',
+
   // Enable vulnerability alerts
   osvVulnerabilityAlerts: true,
 

--- a/renovate-config.js
+++ b/renovate-config.js
@@ -1,0 +1,39 @@
+module.exports = {
+  platform: 'github',
+  timezone: 'Australia/Brisbane',
+  requireConfig: 'optional',
+  onboarding: false,
+
+  repositories: ['OctopusDeploy/openfeature-provider-java'],
+  reviewers: ['team:team-devex'],
+  branchPrefix: 'renovate/',
+
+  // Limit concurrent PRs for better manageability
+  prConcurrentLimit: 5,
+
+  // Add labels to PRs
+  labels: ['dependencies'],
+
+  // Enable vulnerability alerts
+  osvVulnerabilityAlerts: true,
+
+  // Produce conventional-commit PR titles so validate-pr-title passes
+  semanticCommits: 'enabled',
+
+  // Extend with recommended config
+  extends: ['config:recommended'],
+
+  // Only manage Maven deps and GitHub Actions (leaves the `specification` submodule alone)
+  enabledManagers: ['maven', 'github-actions'],
+
+  packageRules: [
+    {
+      // GitHub Actions: pin third-party actions to a commit SHA for security.
+      matchManagers: ['github-actions'],
+      matchPackageNames: [
+        '!actions/**', // Trust official GitHub actions (checkout, setup-java, etc.); don't pin.
+      ],
+      pinDigests: true,
+    },
+  ],
+};


### PR DESCRIPTION
- Adds Renovate for automated dependency updates (based on the OctoToggle config)
- Adds workflow to run `renovatebot/github-action` on a cron
- 2-day minimum release age
- Validated with `renovate-config-validator` and a dry run locally shows 13 PRs would be raised

Fixes BMBB-474
Fixes BMBB-498